### PR TITLE
Remove access to the root FS from lua

### DIFF
--- a/Themes/_fallback/Scripts/01 IniFile.lua
+++ b/Themes/_fallback/Scripts/01 IniFile.lua
@@ -107,7 +107,7 @@ IniFile =
 		local file = RageFileUtil.CreateRageFile()
 
 		if not file:Open(file_path, RageFile.WRITE) then
-			Warn( string.format("WriteFile(%s): %s",file_path.file:GetError()) )
+			Warn( string.format("WriteFile(%s): %s",file_path,file:GetError()) )
 			file:destroy()
 			return false
 		end

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -386,16 +386,6 @@ RString ArchHooks_Unix::GetClipboard()
 static LocalizedString COULDNT_FIND_SONGS( "ArchHooks_Unix", "Couldn't find 'Songs'" );
 void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 {
-#if defined(UNIX)
-	/* Mount the root filesystem, so we can read files in /proc, /etc, and so on.
-	 * This is /rootfs, not /root, to avoid confusion with root's home directory. */
-	FILEMAN->Mount( "dir", "/", "/rootfs" );
-
-	/* Mount /proc, so Alsa9Buf::GetSoundCardDebugInfo() and others can access it.
-	 * (Deprecated; use rootfs.) */
-	FILEMAN->Mount( "dir", "/proc", "/proc" );
-#endif
-
 	RString Root;
 	struct stat st;
 	if( !stat(sDirOfExecutable + "/Packages", &st) && st.st_mode&S_IFDIR )

--- a/src/arch/Sound/ALSA9Dynamic.cpp
+++ b/src/arch/Sound/ALSA9Dynamic.cpp
@@ -1,6 +1,7 @@
 #include "global.h"
 
 #include <dlfcn.h>
+#include <sys/stat.h>
 
 #define ALSA_PCM_NEW_HW_PARAMS_API
 #define ALSA_PCM_NEW_SW_PARAMS_API
@@ -28,7 +29,8 @@ RString LoadALSA()
 	 * on use, and this would prevent that from happening.  I don't know if anyone actually
 	 * does that, though: they're often configured to load snd (the core module) if ALSA
 	 * devices are accessed, but hardware drivers are typically loaded on boot. */
-	if( !IsADirectory("/rootfs/proc/asound/") )
+	struct stat st;
+	if (stat("/proc/asound/", &st) == -1 || !(st.st_mode & S_IFDIR))
 		return "/proc/asound/ does not exist";
 
 	ASSERT( Handle == nullptr );

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -5,6 +5,9 @@
 #include "ALSA9Dynamic.h"
 #include "PrefsManager.h"
 
+#include <fstream>
+#include <string>
+
 /* int err; must be defined before using this macro */
 #define ALSA_CHECK(x) \
        if ( err < 0 ) { LOG->Info("ALSA: %s: %s", x, dsnd_strerror(err)); return false; }
@@ -140,11 +143,12 @@ void Alsa9Buf::GetSoundCardDebugInfo()
 		return;
 	done = true;
 
-	if( DoesFileExist("/rootfs/proc/asound/version") )
+	std::ifstream f("/proc/asound/version");
+	if (f.good())
 	{
-		RString sVersion;
-		GetFileContents( "/rootfs/proc/asound/version", sVersion, true );
-		LOG->Info( "ALSA: %s", sVersion.c_str() );
+		std::string version;
+		std::getline(f, version);
+		LOG->Info( "ALSA: %s", version.c_str() );
 	}
 
 	InitializeErrorHandler();

--- a/src/arch/Sound/RageSoundDriver_OSS.cpp
+++ b/src/arch/Sound/RageSoundDriver_OSS.cpp
@@ -4,7 +4,6 @@
 #include "RageLog.h"
 #include "RageSound.h"
 #include "RageSoundManager.h"
-#include "RageUtil.h"
 
 #if defined(HAVE_UNISTD_H)
 #include <unistd.h>
@@ -17,6 +16,7 @@
 #include <sys/ioctl.h>
 #include <sys/soundcard.h>
 #include <sys/select.h>
+#include <sys/stat.h>
 
 REGISTER_SOUND_DRIVER_CLASS( OSS );
 
@@ -138,7 +138,8 @@ RString RageSoundDriver_OSS::CheckOSSVersion( int fd )
 	 */
 #ifndef FORCE_OSS
 #define ALSA_SNDRV_OSS_VERSION         ((3<<16)|(8<<8)|(1<<4)|(0))
-	if( version == ALSA_SNDRV_OSS_VERSION && IsADirectory("/rootfs/proc/asound") )
+	struct stat st;
+	if( version == ALSA_SNDRV_OSS_VERSION && stat("/proc/asound", &st) && (st.st_mode & S_IFDIR) )
 		return "RageSoundDriver_OSS: ALSA detected.  ALSA OSS emulation is buggy; use ALSA natively.";
 #endif
 	if( version )


### PR DESCRIPTION
On linux / is mounted to /rootfs in RageFile, which allows access to the whole filesystem from lua. This means themes and mod files can re-write user data and extract files via USB profiles.

/rootfs was only added for internal use by the alsa, oss and memory card drivers, so it can be easily replaced with direct fstream file access.