### PR TITLE
Remove unsafe package library

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -271,7 +271,6 @@
 		<Function name='rec_count_children'/>
 		<Function name='rec_print_children'/>
 		<Function name='rec_print_table'/>
-		<Function name='require'/>
 		<Function name='round'/>
 		<Function name='scale'/>
 		<Function name='scale_to_fit'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -580,10 +580,6 @@ save yourself some time, copy this for undocumented things:
 	<Function name='ReportStyle' return='void' arguments=''>
 		Sends the current style to the server.
 	</Function>
-	<Function name='require' return='void' arguments='string modname'>
-		Loads the specified module.<br />
-		<code>require</code> is a core function of Lua's basic library; see the Lua manual for more details.
-	</Function>
 	<Function name='round' theme='_fallback' return='int' arguments='float val, int decimal'>
 		[02 Utilities.lua] Round a number.
 	</Function>

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -263,13 +263,6 @@ LuaManager::LuaManager()
 	lua_pushcfunction( L, luaopen_string ); lua_call( L, 0, 0 );
 	lua_pushcfunction( L, luaopen_table ); lua_call( L, 0, 0 );
 	lua_pushcfunction( L, luaopen_debug ); lua_call( L, 0, 0 );
-	lua_pushcfunction( L, luaopen_package ); lua_call( L, 0, 0 ); // this one seems safe -shake
-	// these two can be dangerous. don't use them
-	// (unless you know what you are doing). -aj
-#if 0
-	lua_pushcfunction( L, luaopen_io ); lua_call( L, 0, 0 );
-	lua_pushcfunction( L, luaopen_os ); lua_call( L, 0, 0 );
-#endif
 
 	// Store the thread pool in a table on the stack, in the main thread.
 #define THREAD_POOL 1


### PR DESCRIPTION
`package.loadlib()` can be used to load a dynamic C library allowing arbitrary code execution in mod charts and themes.

So far I haven't found any theme that depends on the library, so I think removing it shouldn't break anything.