### PR TITLE
[Downloads 2/8] Allow to mark preferences as immutable or compat

### DIFF
--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -42,14 +42,14 @@ static Preference<bool>	g_bMemoryCards( "MemoryCards", false );
 static Preference<bool>	g_bMemoryCardProfiles( "MemoryCardProfiles", true );
 
 // if set, always use the device that mounts to this point
-Preference1D<RString>		MemoryCardManager::m_sMemoryCardOsMountPoint( MemoryCardOsMountPointInit,	NUM_PLAYERS );
+Preference1D<RString>	MemoryCardManager::m_sMemoryCardOsMountPoint( MemoryCardOsMountPointInit, NUM_PLAYERS, PreferenceType::Immutable );
 
 // Look for this level, bus, port when assigning cards. -1 = match any
-Preference1D<int>		MemoryCardManager::m_iMemoryCardUsbBus( MemoryCardUsbBusInit,			NUM_PLAYERS );
-Preference1D<int>		MemoryCardManager::m_iMemoryCardUsbPort( MemoryCardUsbPortInit,			NUM_PLAYERS );
-Preference1D<int>		MemoryCardManager::m_iMemoryCardUsbLevel( MemoryCardUsbLevelInit,		NUM_PLAYERS );
+Preference1D<int>	MemoryCardManager::m_iMemoryCardUsbBus( MemoryCardUsbBusInit, NUM_PLAYERS, PreferenceType::Immutable );
+Preference1D<int>	MemoryCardManager::m_iMemoryCardUsbPort( MemoryCardUsbPortInit, NUM_PLAYERS, PreferenceType::Immutable );
+Preference1D<int>	MemoryCardManager::m_iMemoryCardUsbLevel( MemoryCardUsbLevelInit, NUM_PLAYERS, PreferenceType::Immutable );
 
-Preference<RString>		MemoryCardManager::m_sEditorMemoryCardOsMountPoint( "EditorMemoryCardOsMountPoint",	"" );
+Preference<RString>	MemoryCardManager::m_sEditorMemoryCardOsMountPoint( "EditorMemoryCardOsMountPoint", "", nullptr, PreferenceType::Immutable );
 
 const RString MEM_CARD_MOUNT_POINT[NUM_PLAYERS] =
 {

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -17,8 +17,8 @@
 
 NetworkManager*	NETWORK = nullptr;	// global and accessible from anywhere in our program
 
-Preference<bool> NetworkManager::httpEnabled("HttpEnabled", false);
-Preference<RString> NetworkManager::httpAllowHosts("HttpAllowHosts", "");
+Preference<bool> NetworkManager::httpEnabled("HttpEnabled", false, nullptr, PreferenceType::Immutable);
+Preference<RString> NetworkManager::httpAllowHosts("HttpAllowHosts", "", nullptr, PreferenceType::Immutable);
 
 static const char *HttpErrorCodeNames[] = {
 	"Blocked",

--- a/src/Preference.cpp
+++ b/src/Preference.cpp
@@ -9,9 +9,10 @@
 
 static SubscriptionManager<IPreference> m_Subscribers;
 
-IPreference::IPreference( const RString& sName ):
+IPreference::IPreference( const RString& sName, PreferenceType type ):
 	m_sName( sName ),
-	m_bIsStatic( false )
+	m_bDoNotWrite( type == PreferenceType::Deprecated ),
+	m_bImmutable( type == PreferenceType::Immutable )
 {
 	m_Subscribers.Subscribe( this );
 }
@@ -81,14 +82,17 @@ void IPreference::ReadFrom( const XNode* pNode, bool bIsStatic )
 	if( pNode->GetAttrValue(m_sName, sVal) )
 	{
 		FromString( sVal );
-		m_bIsStatic = bIsStatic;
+		if (bIsStatic)
+			m_bDoNotWrite = true;
 	}
 }
 
 void IPreference::WriteTo( XNode* pNode ) const
 {
-	if( !m_bIsStatic )
-		pNode->AppendAttr( m_sName, ToString() );
+	if (m_bDoNotWrite)
+		return;
+
+	pNode->AppendAttr( m_sName, ToString() );
 }
 
 /* Load our value from the node, and make it the new default. */

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -264,9 +264,9 @@ PrefsManager::PrefsManager() :
 	m_CourseSortOrder		( "CourseSortOrder",			COURSE_SORT_SONGS ),
 	m_bSubSortByNumSteps		( "SubSortByNumSteps",			false ),
 	m_GetRankingName		( "GetRankingName",			RANKING_ON ),
-	m_sAdditionalSongFolders	( "AdditionalSongFolders",		"" ),
-	m_sAdditionalCourseFolders	( "AdditionalCourseFolders",		"" ),
-	m_sAdditionalFolders		( "AdditionalFolders",			"" ),
+	m_sAdditionalSongFolders	( "AdditionalSongFolders",		"", nullptr, PreferenceType::Immutable ),
+	m_sAdditionalCourseFolders	( "AdditionalCourseFolders",		"", nullptr, PreferenceType::Immutable ),
+	m_sAdditionalFolders		( "AdditionalFolders",			"", nullptr, PreferenceType::Immutable ),
 	m_sDefaultTheme			( "DefaultTheme",			"default" ),
 	m_sLastSeenVideoDriver		( "LastSeenVideoDriver",		"" ),
 	m_sVideoRenderers		( "VideoRenderers",			"" ),	// StepMania.cpp sets these on first run:
@@ -574,6 +574,11 @@ public:
 			LuaHelpers::ReportScriptErrorFmt( "SetPreference: unknown preference \"%s\"", sName.c_str() );
 			COMMON_RETURN_SELF;
 		}
+		else if (pPref->IsImmutable())
+		{
+			LuaHelpers::ReportScriptErrorFmt( "SetPreference: preference \"%s\" is immutable", sName.c_str() );
+			COMMON_RETURN_SELF;
+		}
 
 		lua_pushvalue( L, 2 );
 		pPref->SetFromStack( L );
@@ -587,6 +592,11 @@ public:
 		if( pPref == nullptr )
 		{
 			LuaHelpers::ReportScriptErrorFmt( "SetPreferenceToDefault: unknown preference \"%s\"", sName.c_str() );
+			COMMON_RETURN_SELF;
+		}
+		else if (pPref->IsImmutable())
+		{
+			LuaHelpers::ReportScriptErrorFmt( "SetPreference: preference \"%s\" is immutable", sName.c_str() );
 			COMMON_RETURN_SELF;
 		}
 

--- a/src/arch/MemoryCard/MemoryCardDriver.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriver.cpp
@@ -22,7 +22,7 @@ XToString(MemoryCardDriverType);
 StringToX(MemoryCardDriverType);
 LuaXType(MemoryCardDriverType);
 
-Preference<MemoryCardDriverType> g_MemoryCardDriver("MemoryCardDriver", MemoryCardDriverType_Usb);
+Preference<MemoryCardDriverType> g_MemoryCardDriver("MemoryCardDriver", MemoryCardDriverType_Usb, nullptr, PreferenceType::Immutable);
 
 bool UsbStorageDevice::operator==(const UsbStorageDevice& other) const
 {


### PR DESCRIPTION
- Compat: The option is read from the settings, but not written back when saving. This can be used for migrating options to a new name or format. (Not used yet.)
- Immutable: The option can not be changed from Lua. Used for security-relevant options that should not be changable by the theme or mod charts. Currently that's networking and some file system access options.
