### PR TITLE
Tweak sort defaults to make more sense

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -981,9 +981,9 @@ ShowRandom=false
 ShowPortal=false
 
 ShowSectionsInBPMSort=true
-SortBPMDivision=20
+SortBPMDivision=10
 ShowSectionsInLengthSort=true
-SortLengthDivision=5
+SortLengthDivision=60
 
 MostPlayedSongsToShow=30
 RecentSongsToShow=30


### PR DESCRIPTION
- SortBPMDivision: Reduce from 20 to 10 to match up with ECS "tiers".
- SortLengthDivision: Increase from 5 seconds to 1 minute. Divisions of 5 seconds don't seem very useful.